### PR TITLE
WIP: Get JuiceBox ID and Clean Up Names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-bookworm
+
+ENV MQTT_HOST="127.0.0.1"
+ENV MQTT_PORT=1883
+ENV MQTT_DISCOVERY_PREFIX="homeassistant"
+ENV DEVICE_NAME="JuiceBox"
+ENV ENELX_PORT=8047
+ENV ENELX_SERVER="juicenet-udp-prod3-usa.enelx.com"
+ENV SRC_DEFAULT="127.0.0.1"
+ENV DST_DEFAULT="54.161.147.91"
+ENV DEBUG=false
+
+RUN pip install --upgrade pip
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y git curl dnsutils net-tools telnet expect
+# RUN apt-get install -y iputils-ping netcat-traditional nano # Used for debugging
+RUN git clone https://github.com/snicker/juicepassproxy.git /juicepassproxy
+RUN pip install --no-cache-dir -r /juicepassproxy/requirements.txt
+
+ENTRYPOINT /juicepassproxy/docker_entrypoint.sh

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+NOW=$(date +'%x %X')
+
+echo "--------------------------------"
+echo "${NOW}: Starting JuicePassProxy"
+echo ""
+
+if [ ! -z "${JUICEBOX_LOCAL_IP+x}" ]; then
+  echo "${NOW}: JUICEBOX_LOCAL_IP: ${JUICEBOX_LOCAL_IP}"
+  TELNET_STRING=$(/juicepassproxy/telnet_get_server.expect ${JUICEBOX_LOCAL_IP} | grep "# 2")
+  retval=$?
+  if [ ${retval} -eq 0 ]; then
+    #echo "${NOW}: TELNET_STRING: ${TELNET_STRING}"
+    ENELX_SERVER=$(echo ${TELNET_STRING} | sed -E 's/(# 2 UDPC[ ]+)(.*)(:.*)/\2/g')
+    #echo "${NOW}: ENELX_SERVER: ${ENELX_SERVER}"
+    ENELX_PORT=$(echo ${TELNET_STRING} | sed -E 's/(.*:)(.*)([ ]+.*)/\2/g')
+    #echo "${NOW}: ENELX_PORT: ${ENELX_PORT}"
+  else
+    echo "ERROR getting EnelX Server from Telnet. Using defaults."
+  fi
+fi
+if [ -z "${SRC+x}" ]; then
+  SRC=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p')
+  retval=$?
+  if [ ${retval} -ne 0 ]; then
+    echo "ERROR getting Docker Local IP. Using default."
+    SRC=${SRC_DEFAULT}
+  fi
+fi
+
+if [ -z "${DST+x}" ]; then
+  DST=$(dig +short @1.1.1.1 ${ENELX_SERVER} | awk '{ getline ; print $1 ; exit }')
+  retval=$?
+  if [ ${retval} -ne 0 ]; then
+    echo "ERROR getting EnelX Server IP. Using default."
+    DST=${DST_DEFAULT}
+  fi
+fi
+
+JPP_STRING="python /juicepassproxy/juicepassproxy.py --src ${SRC}:${ENELX_PORT} --dst ${DST}:${ENELX_PORT} --host ${MQTT_HOST} --port ${MQTT_PORT} --discovery-prefix ${MQTT_DISCOVERY_PREFIX} --name ${DEVICE_NAME}"
+
+echo "${NOW}: SRC: ${SRC}"
+echo "${NOW}: DST: ${DST}"
+echo "${NOW}: ENELX_SERVER: ${ENELX_SERVER}"
+echo "${NOW}: ENELX_PORT: ${ENELX_PORT}"
+echo "${NOW}: MQTT_HOST: ${MQTT_HOST}"
+echo "${NOW}: MQTT_PORT: ${MQTT_PORT}"
+if [ ! -z "${MQTT_USER+x}" ]; then
+  echo "${NOW}: MQTT_USER: ${MQTT_USER}"
+  JPP_STRING+=" --user ${MQTT_USER}"
+fi
+if [ ! -z "${MQTT_PASS+x}" ]; then
+  echo "${NOW}: MQTT_PASS: $(echo ${MQTT_PASS} | sed -E 's/./*/g')"
+  JPP_STRING+=" --password ${MQTT_PASS}"
+fi
+echo "${NOW}: MQTT_DISCOVERY_PREFIX: ${MQTT_DISCOVERY_PREFIX}"
+echo "${NOW}: DEVICE_NAME: ${DEVICE_NAME}"
+echo "${NOW}: DEBUG: ${DEBUG}"
+
+if [ "${DEBUG}" = true ] ; then
+  JPP_STRING+=" --debug"
+fi
+
+echo "${NOW}: COMMAND: $(echo ${JPP_STRING} | sed -E 's/(--password )(\<.*\>)(.*)/\1*****\3/')"
+eval ${JPP_STRING}

--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -85,6 +85,7 @@ class JuiceboxMessageHandler(object):
         name = "{} Power (Lifetime)".format(self.device_name)
         sensor_info = SensorInfo(name=name, unique_id=name, 
                                  state_class='total_increasing',
+                                 device_class="energy",
                                  unit_of_measurement='Wh',
                                  device=device_info)
         settings = Settings(mqtt=self.mqtt_settings, entity=sensor_info)
@@ -95,6 +96,7 @@ class JuiceboxMessageHandler(object):
         name = "{} Power (Session)".format(self.device_name)
         sensor_info = SensorInfo(name=name, unique_id=name, 
                                  state_class='total_increasing',
+                                 device_class="energy",
                                  unit_of_measurement='Wh',
                                  device=device_info)
         settings = Settings(mqtt=self.mqtt_settings, entity=sensor_info)

--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -65,6 +65,7 @@ class JuiceboxMessageHandler(object):
         name = "{} Current".format(self.device_name)
         sensor_info = SensorInfo(name=name, unique_id=name, 
                                  state_class='measurement',
+                                 device_class="current",
                                  unit_of_measurement='A',
                                  device=device_info)
         settings = Settings(mqtt=self.mqtt_settings, entity=sensor_info)
@@ -75,6 +76,7 @@ class JuiceboxMessageHandler(object):
         name = "{} Frequency".format(self.device_name)
         sensor_info = SensorInfo(name=name, unique_id=name, 
                                  state_class='measurement',
+                                 device_class="frequency",
                                  unit_of_measurement='Hz',
                                  device=device_info)
         settings = Settings(mqtt=self.mqtt_settings, entity=sensor_info)
@@ -107,6 +109,7 @@ class JuiceboxMessageHandler(object):
         name = "{} Temperature".format(self.device_name)
         sensor_info = SensorInfo(name=name, unique_id=name, 
                                  state_class='measurement',
+                                 device_class="temperature",
                                  unit_of_measurement='°F',
                                  device=device_info)
         settings = Settings(mqtt=self.mqtt_settings, entity=sensor_info)
@@ -117,6 +120,7 @@ class JuiceboxMessageHandler(object):
         name = "{} Voltage".format(self.device_name)
         sensor_info = SensorInfo(name=name, unique_id=name, 
                                  state_class='measurement',
+                                 device_class="voltage",
                                  unit_of_measurement='V',
                                  device=device_info)
         settings = Settings(mqtt=self.mqtt_settings, entity=sensor_info)

--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -129,8 +129,8 @@ class JuiceboxMessageHandler(object):
 
     def basic_message_try_parse(self, data):
         message = {"type": "basic"}
-        message = {"current": 0}
-        message = {"power_session": 0}
+        message["current"] = 0
+        message["power_session"] = 0
         for part in str(data).split(","):
             if part[0] == "S":
                 message["status"] = {

--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -129,12 +129,12 @@ class JuiceboxMessageHandler(object):
             if message['status'] is None:
                 message['status'] = 'unknown {}'.format(parts[5])
             active = message['status'] == 'charging'
-            message['current'] = float(parts[16].split('A')[1])*0.1 if active else 0.0
-            message['frequency'] = float(parts[12].split('f')[1])*0.01
+            message['current'] = round(float(parts[16].split('A')[1])*0.1,2) if active else 0.0
+            message['frequency'] = round(float(parts[12].split('f')[1])*0.01,2)
             message['power_lifetime'] = float(parts[4].split('L')[1])
             message['power_session'] = float(parts[15].split('E')[1]) if active else 0.0
-            message['temperature'] = float(parts[6].split('T')[1])*1.8+32
-            message['voltage'] = float(parts[3].split('V')[1])*0.1
+            message['temperature'] = round(float(parts[6].split('T')[1])*1.8+32,2)
+            message['voltage'] = round(float(parts[3].split('V')[1])*0.1,2)
         except Exception as e:
             logging.debug('failed to process basic message: {}'.format(e))
             return None

--- a/telnet_get_juicebox_id.expect
+++ b/telnet_get_juicebox_id.expect
@@ -1,0 +1,9 @@
+#!/usr/bin/expect
+
+set host [lindex $argv 0]
+
+set timeout 20
+spawn telnet $host 2000 
+expect ">"
+send "get email.name_address\r"
+expect ">"

--- a/telnet_get_server.expect
+++ b/telnet_get_server.expect
@@ -1,0 +1,9 @@
+#!/usr/bin/expect
+
+set host [lindex $argv 0]
+
+set timeout 20
+spawn telnet $host 2000 
+expect ">"
+send "list\r"
+expect ">"


### PR DESCRIPTION
Requires #2, #4, #5

Gets the JuiceBox ID via Telnet and uses in the Device Info and Unique ID.
Removes the name (JuiceBox) from the Entity Name to align with HA Naming Convention (and prevent the Warning in HA logs).

ToDo:
* Make the JuiceBox ID, EnelX Server, and DST persist in case the JuiceBox Telnet isn't available or doesn't work when the Docker container starts up.