### PR TITLE
GitHub Workflow to Create GitHub Container Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,46 @@
+name: Build and Publish GitHub Container Docker Image
+on:
+  release:
+    types: [published, edited]
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  build_and_publish_docker_image:
+    if: github.repository_owner == 'snicker'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v4.1.1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=edge,branch=main
+            type=semver,pattern={{version}}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push Docker Container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-bookworm
+FROM python:3.12-slim-bookworm
 
 ENV MQTT_HOST="127.0.0.1"
 ENV MQTT_PORT=1883


### PR DESCRIPTION
* It will create multi-arch images for: linux/amd64, linux/arm64, linux/arm/v7
* For any release, it will create images with the `<version number>` and `latest` tags
    * The release tag **must** be valid [semver](https://semver.org/)
    * For pre-releases, it will create the `<version number>` tag but not `latest`
* For any push and pull-request merge to the `master` (or `main`) branch, it will create images with the `edge` tag
* It will only run for @snicker and not for forks of the repo
* Dependabot should auto-create PRs to update the workflow versions (if enabled in the Repo settings).

@snicker if you want to use this, please merge it and then make a first release (maybe `v0.1.0`). I can then test to ensure it works and will then make another PR to update the Readme with revised Docker Compose instructions.

The docker image location should be: `ghcr.io/snicker/juicepassproxy`