### PR TITLE
WIP add python telnet client for Juicebox to avoid DNS requirements

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,6 +2,8 @@
 
 This tool will publish JuiceBox data by using a Man in the Middle UDP proxy to MQTT that is auto-discoverable by HomeAssistant. The `Enel X Way` app will continue to function.
 
+It can also publish the IP of the proxy to the Juicebox directly to avoid using custom local DNS servers using the `update_udpc` and `juicebox_host` command line parameters (not yet supported in Docker).
+
 Builds upon work by lovely folks in this issue: https://github.com/home-assistant/core/issues/86588
 
 _Hopefully we won't need this if EnelX fixes their API!_
@@ -91,6 +93,7 @@ Variable | Required | Description & Default |
 4. Launch by executing `python juicepassproxy.py --dst <enelx IP:port> --host <mqtthost>` (params documented below)
 5. Nothing happens!
 6. Configure your DNS server running on your network (like Pi-hole or your router) to route all DNS requests from EnelX to the machine running this proxy. For me this was `juicenet-udp-prod3-usa.enelx.com`. See below for instructions to determine that.
+7. Alternatively to #6, you can enable `update_udpc` on the command line and set `juicebox_host` and the application will force publish the IP in the `src` flag to the Juicebox and avoid the need to set DNS rules on your router or DNS server.
 
 ### CLI Options
 
@@ -108,6 +111,9 @@ options:
   -D DISCOVERY_PREFIX, --discovery-prefix DISCOVERY_PREFIX
                         Home Assistant MQTT topic prefix (default: homeassistant)
   --name DEVICE_NAME    Home Assistant Device Name (default: Juicebox)
+  --update_udpc         Update UDPC on the Juicebox. Requires --juicebox_host
+  --juicebox_host JUICEBOX_HOST
+                        host or IP address of the Juicebox. required for --update_udpc
 ```
 
 _For **DST**, you should only use the IP address of the EnelX Server and **not** the fully qualified domain name (FQDN) to avoid DNS lookup loops._

--- a/juicebox_telnet.py
+++ b/juicebox_telnet.py
@@ -1,0 +1,69 @@
+from telnetlib import Telnet
+import logging
+
+class JuiceboxTelnet(object):
+    def __init__(self, host, port=2000):
+        self.host = host
+        self.port = port
+        self.connection = None
+
+    def __enter__(self):
+        self.connection = self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        if self.connection:
+            self.connection.close()
+        self.connection = None
+
+    def open(self):
+        if not self.connection:
+            self.connection = Telnet(host=self.host, port=self.port)
+            self.connection.read_until(b">")
+        return self.connection
+
+    def list(self):
+        tn = self.open()
+        tn.write(b"\n")
+        tn.read_until(b"> ")
+        tn.write(b"list\n")
+        tn.read_until(b"list\r\n! ")
+        res = tn.read_until(b">")
+        lines = str(res[:-3]).split("\\r\\n")
+        out = []
+        for line in lines[1:]:
+            parts = line.split(" ")
+            if len(parts) >= 5:
+                out.append({
+                    'id': parts[1],
+                    'type': parts[2],
+                    'dest': parts[4]
+                })
+        return out
+    
+    def get(self, variable):
+        tn = self.open()
+        tn.write(b"\n")
+        tn.read_until(b"> ")
+        cmd = f"get {variable}\r\n".encode("ascii")
+        tn.write(cmd)
+        tn.read_until(cmd)
+        res = tn.read_until(b">")
+        return {variable: str(res[:-1].strip())}
+
+    def get_all(self):
+        tn = self.open()
+        tn.write(b"\n")
+        tn.read_until(b"> ")
+        cmd = f"get all\r\n".encode("ascii")
+        tn.write(cmd)
+        tn.read_until(cmd)
+        res = tn.read_until(b">")
+        lines = str(res[:-1]).split("\\r\\n")
+        vars = {}
+        for line in lines:
+            parts = line.split(": ")
+            if len(parts) == 2:
+                vars[parts[0]] = parts[1]
+        return vars
+        

--- a/juicebox_telnet.py
+++ b/juicebox_telnet.py
@@ -54,7 +54,7 @@ class JuiceboxTelnet(object):
     def get_all(self):
         tn = self.open()
         tn.write(b"\n")
-        tn.read_until(b"> ")
+        tn.read_until(b">")
         cmd = f"get all\r\n".encode("ascii")
         tn.write(cmd)
         tn.read_until(cmd)
@@ -67,3 +67,23 @@ class JuiceboxTelnet(object):
                 vars[parts[0]] = parts[1]
         return vars
         
+    def stream_close(self, id):
+        tn = self.open()
+        tn.write(b"\n")
+        tn.read_until(b">")
+        tn.write(f"stream_close {id}".encode('ascii'))
+        tn.read_until(b">")
+
+    def udpc(self, host, port):
+        tn = self.open()
+        tn.write(b"\n")
+        tn.read_until(b">")
+        tn.write(f"udpc {host} {port}".encode('ascii'))
+        tn.read_until(b">")
+
+    def save(self):
+        tn = self.open()
+        tn.write(b"\n")
+        tn.read_until(b">")
+        tn.write(b"save")
+        tn.read_until(b">")

--- a/juicebox_telnet.py
+++ b/juicebox_telnet.py
@@ -71,19 +71,19 @@ class JuiceboxTelnet(object):
         tn = self.open()
         tn.write(b"\n")
         tn.read_until(b">")
-        tn.write(f"stream_close {id}".encode('ascii'))
+        tn.write(f"stream_close {id}\n".encode('ascii'))
         tn.read_until(b">")
 
     def udpc(self, host, port):
         tn = self.open()
         tn.write(b"\n")
         tn.read_until(b">")
-        tn.write(f"udpc {host} {port}".encode('ascii'))
+        tn.write(f"udpc {host} {port}\n".encode('ascii'))
         tn.read_until(b">")
 
     def save(self):
         tn = self.open()
         tn.write(b"\n")
         tn.read_until(b">")
-        tn.write(b"save")
+        tn.write(b"save\n")
         tn.read_until(b">")

--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -362,5 +362,5 @@ def main():
         udpc_updater.run_event = False
         udpc_updater_thread.join()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
will be used to periodically set the UDPC stream on the juicebox. 

example:

```
with JuiceboxTelnet('192.168.1.39',2000) as tn:
    ip_to_verify = "192.168.1.183"
    connections = tn.list()
    for connection in connections:
        logging.debug(f"checking {connection}")
        if connection['type'] == 'UDPC':
            if ip_to_verify not in connection.get('dest'):
                logging.info('IP not set!')
                tn.stream_close(connection['id'])
                tn.udpc(ip_to_verify, 8047)
                tn.save()
            else:
                logging.info('IP set correctly')
```