### PR TITLE
Update Docker entrypoint for Update UDPC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.12-slim-bookworm
+# WARNING: Do not update python past 3.12.* if telnetlib is still being used.
+
 LABEL org.opencontainers.image.source=https://github.com/snicker/juicepassproxy
 
 ENV MQTT_HOST="127.0.0.1"

--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,7 @@
 
 This tool will publish JuiceBox data by using a Man in the Middle UDP proxy to MQTT that is auto-discoverable by HomeAssistant. The `Enel X Way` app will continue to function.
 
-It can also publish the IP of the proxy to the Juicebox directly to avoid using custom local DNS servers using the `update_udpc` and `juicebox_host` command line parameters (not yet supported in Docker).
+It can also publish the IP of the proxy to the JuiceBox directly to avoid using custom local DNS servers using the `update_udpc` and `juicebox_host` command line parameters.
 
 Builds upon work by lovely folks in this issue: https://github.com/home-assistant/core/issues/86588
 
@@ -19,9 +19,20 @@ _Hopefully we won't need this if EnelX fixes their API!_
 
 *  If SRC is not defined, it will use `ifconfig` to get the Local IP address of the Docker.
 
+* If Update UDPC is true, JuicePass Proxy will continually update the JuiceBox via telnet to send its data to JuicePass Proxy. Use this if you are not able to change your DNS to route the JuiceBox traffic to JuicePass Proxy.
+
 ### Instructions
 
-1. Configure your DNS server running on your network (like Pi-hole or your router) to route all UDP traffic from your JuiceBox to the machine running this proxy. Instructions for how to do this will vary by router. See [Getting EnelX Server IPs](#getting-enelx-server-ips) for instructions on what EnelX Server you need to override.
+1. Pick One Option:
+
+    A. Configure your DNS server running on your network (like Pi-hole or your router) to route all UDP traffic from your JuiceBox to the machine running this proxy. Instructions for how to do this will vary by router. See [Getting EnelX Server IPs](#getting-enelx-server-ips) for instructions on what EnelX Server you need to override.
+
+    B. Set these Docker Environment Variables in your Docker Compose file:</br>
+      ```
+      UPDATE_UDPC=true
+      JUICEBOX_HOST=<IP address of your JuiceBox
+      JPP_HOST=<IP address of the machine that the JuicePass Proxy Docker Container is running on>
+      ```
 
 1. Add the `juicepassproxy` service to your Docker Compose file.
 
@@ -56,7 +67,9 @@ services:
     ports:
       - 8047:8047/udp
     environment:
-      - JUICEBOX_LOCAL_IP=10.100.50.30
+      - JUICEBOX_HOST=10.100.50.30
+      - UPDATE_UDPC=true
+      - JPP_HOST=10.100.200.50
       - MQTT_HOST=10.100.200.5
       - MQTT_USER=mosquitto
       - MQTT_PASS=***
@@ -69,7 +82,7 @@ services:
 
 Variable | Required | Description & Default |
 -- | -- | --
-**JUICEBOX_LOCAL_IP** | **Recommended** | If defined, it will attempt to get the EnelX Server and Port using Telnet. If unsuccessful, it will default to the EnelX Server and Port below.
+**JUICEBOX_HOST** | **Recommended**</br></br>**Required if Update UDPC is True.** | If defined, it will attempt to get the EnelX Server and Port using Telnet. If unsuccessful, it will default to the EnelX Server and Port below.
 **SRC** | No | If not defined, it will attempt to get the Local Docker IP. If unsuccessful, it will default to 127.0.0.1.
 **DST** | No | If not defined, it will attempt to get the IP of the EnelX Server. If unsuccessful, it will default to 54.161.185.130. If manually defined, you should only use the IP address of the EnelX Server and not the fully qualified domain name to avoid DNS lookup loops.
 **JUICEBOX_ID**  | No | If not defined, it will attempt to get the JuiceBox ID using Telnet.  
@@ -81,6 +94,8 @@ Variable | Required | Description & Default |
 **MQTT_PASS** | No |
 **MQTT_DISCOVERY_PREFIX** | No | homeassistant
 **DEVICE_NAME** | No | JuiceBox
+**UPDATE_UDPC** | No | Default: false. If true, will continually update the JuiceBox via telnet to point to JuicePass Proxy.
+**JPP_HOST**  | **Required if Update UDPC is True** |  This is the IP or Hostname of the machine where JuicePass Proxy is running (**not** the IP of the Docker Container)
 **DEBUG** | No | false
 
 
@@ -93,7 +108,7 @@ Variable | Required | Description & Default |
 4. Launch by executing `python juicepassproxy.py --dst <enelx IP:port> --host <mqtthost>` (params documented below)
 5. Nothing happens!
 6. Configure your DNS server running on your network (like Pi-hole or your router) to route all DNS requests from EnelX to the machine running this proxy. For me this was `juicenet-udp-prod3-usa.enelx.com`. See below for instructions to determine that.
-7. Alternatively to #6, you can enable `update_udpc` on the command line and set `juicebox_host` and the application will force publish the IP in the `src` flag to the Juicebox and avoid the need to set DNS rules on your router or DNS server.
+7. Alternatively to #6, you can enable `update_udpc` on the command line and set `juicebox_host` and the application will force publish the IP in the `src` flag to the JuiceBox and avoid the need to set DNS rules on your router or DNS server.
 
 ### CLI Options
 
@@ -111,9 +126,15 @@ options:
   -D DISCOVERY_PREFIX, --discovery-prefix DISCOVERY_PREFIX
                         Home Assistant MQTT topic prefix (default: homeassistant)
   --name DEVICE_NAME    Home Assistant Device Name (default: Juicebox)
-  --update_udpc         Update UDPC on the Juicebox. Requires --juicebox_host
+  --juicebox_id JUICEBOX_ID
+                        JuiceBox ID
+  --update_udpc         Update UDPC on the JuiceBox. Requires --juicebox_host
   --juicebox_host JUICEBOX_HOST
-                        host or IP address of the Juicebox. required for --update_udpc
+                        Host or IP address of the JuiceBox. required for --update_udpc
+  --jpp_host JPP_HOST
+                        Host or IP address of the machine that JuicePass Proxy is running on.
+                        Required if --update_udpc is true and --src is not the address of the
+                        machine. (Needed for Docker in bridge mode)
 ```
 
 _For **DST**, you should only use the IP address of the EnelX Server and **not** the fully qualified domain name (FQDN) to avoid DNS lookup loops._

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -74,9 +74,9 @@ else
   logger DEBUG "No Config File Found."
 fi
 
-if [[ ! -z "${JUICEBOX_LOCAL_IP}" ]]; then
+if [[ ! -z "${JUICEBOX_HOST}" ]]; then
   if [[ -z "${JUICEBOX_ID}" ]]; then
-    JUICEBOX_ID=$(${TELNET_GET_JUICEBOX_ID} ${JUICEBOX_LOCAL_IP} | sed -n 8p)
+    JUICEBOX_ID=$(${TELNET_GET_JUICEBOX_ID} ${JUICEBOX_HOST} | sed -n 8p)
     if [[ ! -z "${JUICEBOX_ID}" ]]; then
       logger DEBUG "Sucessfully obtained JuiceBox ID."
       JUICEBOX_ID=${JUICEBOX_ID%?}
@@ -91,12 +91,21 @@ if [[ ! -z "${JUICEBOX_LOCAL_IP}" ]]; then
     fi
   fi
 
-  TELNET_SERVER_STRING=$(${TELNET_GET_SERVER} ${JUICEBOX_LOCAL_IP} | grep "UDPC")
+  TELNET_SERVER_STRING=$(${TELNET_GET_SERVER} ${JUICEBOX_HOST} | grep "UDPC" | head -1)
   if [[ ! -z "${TELNET_SERVER_STRING}" ]]; then
     logger DEBUG "Sucessfully obtained EnelX Server and Port."
     #logger debug "TELNET_SERVER_STRING: ${TELNET_SERVER_STRING}"
     ENELX_SERVER=$(echo ${TELNET_SERVER_STRING} | sed -E 's/(# 2 UDPC[ ]+)(.*)(:.*)/\2/g')
     ENELX_PORT=$(echo ${TELNET_SERVER_STRING} | sed -E 's/(.*:)(.*)([ ]+.*)/\2/g')
+    if valid_ip ${ENELX_SERVER}; then
+      if [[ ! -z "${ENELX_SERVER_CONFIG}" ]] && ! valid_ip ${ENELX_SERVER_CONFIG}; then
+        logger WARNING "EnelX Server is already an IP. Using config."
+        ENELX_SERVER=${ENELX_SERVER_CONFIG}
+      else
+        logger ERROR "EnelX Server is already an IP. Not set in config. Using default."
+        ENELX_SERVER=${ENELX_SERVER_DEFAULT}
+      fi
+    fi
   else
     if [[ ! -z "${ENELX_SERVER_CONFIG}" ]]; then
       logger WARNING "Cannot get EnelX Server from Telnet. Using config."
@@ -146,10 +155,10 @@ fi
 JPP_STRING="python3 ${JUICEPASSPROXY} --src ${SRC}:${ENELX_PORT} --dst ${DST}:${ENELX_PORT} --host ${MQTT_HOST} --port ${MQTT_PORT} --discovery-prefix ${MQTT_DISCOVERY_PREFIX} --name ${DEVICE_NAME}"
 echo ""
 logger INFO "DEVICE_NAME: ${DEVICE_NAME}"
-logger INFO "JUICEBOX_LOCAL_IP: ${JUICEBOX_LOCAL_IP}"
+logger INFO "JUICEBOX_HOST: ${JUICEBOX_HOST}"
 if [[ ! -z "${JUICEBOX_ID}" ]]; then
   logger INFO "JUICEBOX_ID: ${JUICEBOX_ID}"
-  JPP_STRING+=" --juicebox-id ${JUICEBOX_ID}"
+  JPP_STRING+=" --juicebox_id ${JUICEBOX_ID}"
 fi
 
 logger INFO "SRC: ${SRC}"
@@ -168,6 +177,14 @@ if [[ ! -z "${MQTT_PASS}" ]]; then
 fi
 
 logger INFO "MQTT_DISCOVERY_PREFIX: ${MQTT_DISCOVERY_PREFIX}"
+
+logger INFO "UPDATE_UDPC: ${UPDATE_UDPC}"
+if $UPDATE_UDPC; then
+  logger INFO "JPP_HOST: ${JPP_HOST}"
+  JPP_STRING+=" --juicebox_host ${JUICEBOX_HOST}"
+  JPP_STRING+=" --jpp_host ${JPP_HOST}"
+  JPP_STRING+=" --update_udpc"
+fi
 
 if $DEBUG; then
   JPP_STRING+=" --debug"
@@ -194,5 +211,5 @@ if $DEBUG; then
   yq e /config/juicepassproxy.yaml
   echo ""
 fi
-logger INFO "COMMAND: $(echo ${JPP_STRING} | sed -E 's/(--password )(\<.*\>)(.*)/\1*****\3/')"
+logger INFO "COMMAND: $(echo ${JPP_STRING} | sed -E 's/(.* --password )([\"]?[a-zA-Z0-9_\?\*\^\&\#\@\!]+[\"]?)/\1*****/g')"
 eval ${JPP_STRING}

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -182,7 +182,7 @@ logger INFO "UPDATE_UDPC: ${UPDATE_UDPC}"
 if $UPDATE_UDPC; then
   logger INFO "JPP_HOST: ${JPP_HOST}"
   JPP_STRING+=" --juicebox_host ${JUICEBOX_HOST}"
-  JPP_STRING+=" --jpp_host ${JPP_HOST}"
+  JPP_STRING+=" --juicebox_proxy_host ${JPP_HOST}"
   JPP_STRING+=" --update_udpc"
 fi
 

--- a/juicebox_telnet.py
+++ b/juicebox_telnet.py
@@ -1,5 +1,5 @@
 from telnetlib import Telnet
-import logging
+
 
 class JuiceboxTelnet(object):
     def __init__(self, host, port=2000):
@@ -34,13 +34,9 @@ class JuiceboxTelnet(object):
         for line in lines[1:]:
             parts = line.split(" ")
             if len(parts) >= 5:
-                out.append({
-                    'id': parts[1],
-                    'type': parts[2],
-                    'dest': parts[4]
-                })
+                out.append({"id": parts[1], "type": parts[2], "dest": parts[4]})
         return out
-    
+
     def get(self, variable):
         tn = self.open()
         tn.write(b"\n")
@@ -55,7 +51,7 @@ class JuiceboxTelnet(object):
         tn = self.open()
         tn.write(b"\n")
         tn.read_until(b">")
-        cmd = f"get all\r\n".encode("ascii")
+        cmd = "get all\r\n".encode("ascii")
         tn.write(cmd)
         tn.read_until(cmd)
         res = tn.read_until(b">")
@@ -66,19 +62,19 @@ class JuiceboxTelnet(object):
             if len(parts) == 2:
                 vars[parts[0]] = parts[1]
         return vars
-        
+
     def stream_close(self, id):
         tn = self.open()
         tn.write(b"\n")
         tn.read_until(b">")
-        tn.write(f"stream_close {id}\n".encode('ascii'))
+        tn.write(f"stream_close {id}\n".encode("ascii"))
         tn.read_until(b">")
 
     def udpc(self, host, port):
         tn = self.open()
         tn.write(b"\n")
         tn.read_until(b">")
-        tn.write(f"udpc {host} {port}\n".encode('ascii'))
+        tn.write(f"udpc {host} {port}\n".encode("ascii"))
         tn.read_until(b">")
 
     def save(self):

--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -2,9 +2,10 @@ import argparse
 import logging
 import time
 from threading import Thread
-from juicebox_telnet import JuiceboxTelnet
+
 from ha_mqtt_discoverable import DeviceInfo, Settings
 from ha_mqtt_discoverable.sensors import Sensor, SensorInfo
+from juicebox_telnet import JuiceboxTelnet
 from pyproxy import pyproxy
 
 AP_DESCRIPTION = """
@@ -236,8 +237,9 @@ class JuiceboxMessageHandler(object):
             self.basic_message_publish(message)
         return data
 
+
 class JuiceboxUDPCUpdater(object):
-    def __init__(self, juicebox_host, udpc_host, udpc_port = 8047):
+    def __init__(self, juicebox_host, udpc_host, udpc_port=8047):
         self.juicebox_host = juicebox_host
         self.udpc_host = udpc_host
         self.udpc_port = udpc_port
@@ -248,34 +250,35 @@ class JuiceboxUDPCUpdater(object):
         while self.run_event:
             try:
                 logging.debug("JuiceboxUDPCUpdater check...")
-                with JuiceboxTelnet(self.juicebox_host,2000) as tn:
+                with JuiceboxTelnet(self.juicebox_host, 2000) as tn:
                     connections = tn.list()
                     update_required = True
                     connection_to_update = None
                     id_to_update = None
 
                     for connection in connections:
-                        if connection['type'] == 'UDPC':
+                        if connection["type"] == "UDPC":
                             connection_to_update = connection
 
                     if connection_to_update is None:
-                        logging.debug('UDPC IP not found, updating...')
-                    elif self.udpc_host not in connection['dest']:
-                        logging.debug('UDPC IP incorrect, updating...')
-                        id_to_update = connection['id']
+                        logging.debug("UDPC IP not found, updating...")
+                    elif self.udpc_host not in connection["dest"]:
+                        logging.debug("UDPC IP incorrect, updating...")
+                        id_to_update = connection["id"]
                     else:
-                        logging.debug('UDPC IP correct')
+                        logging.debug("UDPC IP correct")
                         update_required = False
-                    
+
                     if update_required:
                         if id_to_update is not None:
                             tn.stream_close(id_to_update)
                         tn.udpc(self.udpc_host, self.udpc_port)
                         tn.save()
-                        logging.debug('UDPC IP Saved')
-            except:
-                logging.exception('Error in JuiceboxUDPCUpdater')
+                        logging.debug("UDPC IP Saved")
+            except Exception as e:
+                logging.exception(f"Error in JuiceboxUDPCUpdater: {e}")
             time.sleep(self.interval)
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -321,15 +324,22 @@ def main():
         dest="device_name",
     )
     parser.add_argument(
-        "--juicebox-id", type=str, help="JuiceBox ID", dest="juicebox_id"
+        "--juicebox_id", type=str, help="JuiceBox ID", dest="juicebox_id"
     )
     parser.add_argument(
-        "--update_udpc", action="store_true",
-        help="Update UDPC on the Juicebox. Requires --juicebox_host"
+        "--update_udpc",
+        action="store_true",
+        help="Update UDPC on the Juicebox. Requires --juicebox_host",
     )
     arg_juicebox_host = parser.add_argument(
-        "--juicebox_host", type=str,
-        help="host or IP address of the Juicebox. required for --update_udpc"
+        "--juicebox_host",
+        type=str,
+        help="host or IP address of the Juicebox. required for --update_udpc",
+    )
+    parser.add_argument(
+        "--jpp_host",
+        type=str,
+        help="Host or IP address of the machine that JuicePass Proxy is running on. Required if --update_udpc is true and --src is not the address of the machine. (Needed for Docker in bridge mode)",
     )
     args = parser.parse_args()
 
@@ -341,7 +351,9 @@ def main():
 
     localhost_src = args.src.startswith("0.") or args.src.startswith("127")
     if args.update_udpc and localhost_src:
-        raise argparse.ArgumentError(arg_src, "src must not be a local IP address for update_udpc to work")
+        raise argparse.ArgumentError(
+            arg_src, "src must not be a local IP address for update_udpc to work"
+        )
 
     mqttsettings = Settings.MQTT(
         host=args.host,
@@ -363,8 +375,11 @@ def main():
     udpc_updater = None
 
     if args.update_udpc:
-        address = args.src.split(':')
-        udpc_updater = JuiceboxUDPCUpdater(args.juicebox_host, address[0], address[1])
+        address = args.src.split(":")
+        jpp_host = address[0]
+        if args.jpp_host:
+            jpp_host = args.jpp_host
+        udpc_updater = JuiceboxUDPCUpdater(args.juicebox_host, jpp_host, address[1])
         udpc_updater_thread = Thread(target=udpc_updater.start)
         udpc_updater_thread.start()
 
@@ -373,6 +388,7 @@ def main():
     if udpc_updater is not None and udpc_updater_thread is not None:
         udpc_updater.run_event = False
         udpc_updater_thread.join()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
# Breaking Changes
Updated the Docker Environment Variables to align with the JuicePass Proxy Arguments:
Old | New | 
-- | -- 
JUICEBOX_LOCAL_IP | `JUICEBOX_HOST`

Updated JuicePass Proxy Argument to use underscore consistently:
Old | New | 
-- | -- 
--juicebox-id | `--juicebox_id`

# Fixes/Enhancements

* Added `UPDATE_UDPC` and `JPP_HOST` Docker Variables
* Add `--jpp_host` as JuicePass Proxy argument for when `--src` isn't the same as the machine IP (like running in Docker bridge mode) and `--update_udpc` is true
* Python code formatting cleanup with black, isort, etc.

