### PR TITLE
Address ValueError max()

### DIFF
--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -265,7 +265,7 @@ class JuiceboxUDPCUpdater(object):
                             if self.udpc_host not in connection["dest"]:
                                 udpc_stream_to_update = int(connection["id"])
                     # logging.debug(f"udpc_streams_to_close: {udpc_streams_to_close}")
-                    if udpc_stream_to_update == 0:
+                    if udpc_stream_to_update == 0 and len(udpc_streams_to_close) > 0:
                         udpc_stream_to_update = int(max(udpc_streams_to_close, key=int))
                     logging.debug(f"Active UDPC Stream: {udpc_stream_to_update}")
 


### PR DESCRIPTION
Fixes #34 

```
juicepassproxy  | 2023-11-16 22:32:53,062 DEBUG      JuiceboxUDPCUpdater check...
juicepassproxy  | 2023-11a-16 22:32:53,287 ERROR      Error in JuiceboxUDPCUpdater: max() iterable argument is empty
juicepassproxy  | Traceback (most recent call last):
juicepassproxy  |   File "/juicepassproxy/juicepassproxy.py", line 269, in start
juicepassproxy  |     udpc_stream_to_update = int(max(udpc_streams_to_close, key=int))
juicepassproxy  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
juicepassproxy  | ValueError: max() iterable argument is empty
```