### PR TITLE
Move config into Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,12 @@ FROM python:3.12-slim-bookworm
 
 LABEL org.opencontainers.image.source=https://github.com/snicker/juicepassproxy
 
-ENV MQTT_HOST="127.0.0.1"
-ENV MQTT_PORT=1883
-ENV MQTT_DISCOVERY_PREFIX="homeassistant"
-ENV DEVICE_NAME="JuiceBox"
 ENV DEBUG=false
+ENV UPDATE_UDPC=false
 
 RUN pip install --upgrade pip
-RUN apt-get update && apt-get install -y gnupg curl
-RUN echo "deb https://ppa.launchpadcontent.net/rmescandon/yq/ubuntu jammy main" > /etc/apt/sources.list.d/yq.list
-RUN echo "deb-src https://ppa.launchpadcontent.net/rmescandon/yq/ubuntu jammy main" >> /etc/apt/sources.list.d/yq.list
-RUN curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x9a2d61f6bb03ced7522b8e7d6657dbe0cc86bb64' | gpg --dearmor | tee /etc/apt/trusted.gpg.d/yq.gpg
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y git dnsutils net-tools telnet expect yq
+RUN apt-get install -y git curl
 RUN git clone https://github.com/snicker/juicepassproxy.git /juicepassproxy
 RUN pip install --no-cache-dir -r /juicepassproxy/requirements.txt
 RUN chmod +x /juicepassproxy/*.sh /juicepassproxy/*.expect

--- a/README.MD
+++ b/README.MD
@@ -30,7 +30,7 @@ _Hopefully we won't need this if EnelX fixes their API!_
     B. Set these Docker Environment Variables in your Docker Compose file:</br>
       ```
       UPDATE_UDPC=true
-      JUICEBOX_HOST=<IP address of your JuiceBox
+      JUICEBOX_HOST=<IP address of your JuiceBox>
       JPP_HOST=<IP address of the machine that the JuicePass Proxy Docker Container is running on>
       ```
 
@@ -83,19 +83,17 @@ services:
 Variable | Required | Description & Default |
 -- | -- | --
 **JUICEBOX_HOST** | **Recommended**</br></br>**Required if Update UDPC is True.** | If defined, it will attempt to get the EnelX Server and Port using Telnet. If unsuccessful, it will default to the EnelX Server and Port below.
+**UPDATE_UDPC** | No | Default: false. If true, will continually update the JuiceBox via telnet to point to JuicePass Proxy.
+**JPP_HOST**  | **Required if Update UDPC is True** |  This is the IP or Hostname of the machine where JuicePass Proxy is running (**not** the IP of the Docker Container)
 **SRC** | No | If not defined, it will attempt to get the Local Docker IP. If unsuccessful, it will default to 127.0.0.1.
 **DST** | No | If not defined, it will attempt to get the IP of the EnelX Server. If unsuccessful, it will default to 54.161.185.130. If manually defined, you should only use the IP address of the EnelX Server and not the fully qualified domain name to avoid DNS lookup loops.
 **JUICEBOX_ID**  | No | If not defined, it will attempt to get the JuiceBox ID using Telnet.  
-**ENELX_SERVER** | No | juicenet-udp-prod3-usa.enelx.com
-**ENELX_PORT** | No | 8047
 **MQTT_HOST** | No | 127.0.0.1
 **MQTT_PORT** | No | 1883
 **MQTT_USER** | No |
 **MQTT_PASS** | No |
 **MQTT_DISCOVERY_PREFIX** | No | homeassistant
 **DEVICE_NAME** | No | JuiceBox
-**UPDATE_UDPC** | No | Default: false. If true, will continually update the JuiceBox via telnet to point to JuicePass Proxy.
-**JPP_HOST**  | **Required if Update UDPC is True** |  This is the IP or Hostname of the machine where JuicePass Proxy is running (**not** the IP of the Docker Container)
 **DEBUG** | No | false
 
 
@@ -103,9 +101,9 @@ Variable | Required | Description & Default |
 <summary><h2>Manual Installation</h2></summary>
 
 1. Clone this repository
-2. Use Python 3.10+ (I recommend setting up a virtual environment)
+2. Use Python 3.10-3.12 (I recommend setting up a virtual environment)
 3. Install requirements `pip install -r requirements.txt`
-4. Launch by executing `python juicepassproxy.py --dst <enelx IP:port> --host <mqtthost>` (params documented below)
+4. Launch by executing `python3 juicepassproxy.py --juicebox_host <IP of the JuiceBox> --mqtt_host <mqtt_host>` (params documented below)
 5. Nothing happens!
 6. Configure your DNS server running on your network (like Pi-hole or your router) to route all DNS requests from EnelX to the machine running this proxy. For me this was `juicenet-udp-prod3-usa.enelx.com`. See below for instructions to determine that.
 7. Alternatively to #6, you can enable `update_udpc` on the command line and set `juicebox_host` and the application will force publish the IP in the `src` argument to the Juicebox and avoid the need to set DNS rules on your router or DNS server. **NOTE: if you need to publish a different IP than the one in the `src` argument, you can make use of the `--juicepass_proxy_host` arg.**
@@ -115,25 +113,36 @@ Variable | Required | Description & Default |
 ```
 options:
   -h, --help            show this help message and exit
-  -s SRC, --src SRC     Source IP and port, (default: 127.0.0.1:8047)
-  -d DST, --dst DST     Destination IP and port of EnelX Server.
+  -s SRC, --src SRC     Source IP (and optional port). If not defined, will
+                        obtain it automatically. (Ex. 127.0.0.1:8047)
+  -d DST, --dst DST     Destination IP (and optional port) of EnelX Server. If
+                        not defined, --juicebox_host required and then will
+                        obtain it automatically. (Ex. 127.0.0.1:8047)
   --debug
-  -u USER, --user USER  MQTT username
-  -P PASSWORD, --password PASSWORD
-                        MQTT password
-  -H HOST, --host HOST  MQTT hostname to connect to (default: 127.0.0.1)
-  -p PORT, --port PORT  MQTT port (default: 1883)
-  -D DISCOVERY_PREFIX, --discovery-prefix DISCOVERY_PREFIX
-                        Home Assistant MQTT topic prefix (default: homeassistant)
-  --name DEVICE_NAME    Home Assistant Device Name (default: Juicebox)
+  -u MQTT_USER, --mqtt_user MQTT_USER
+                        MQTT Username
+  -P MQTT_PASSWORD, --mqtt_password MQTT_PASSWORD
+                        MQTT Password
+  -H MQTT_HOST, --mqtt_host MQTT_HOST
+                        MQTT Hostname to connect to (default: 127.0.0.1)
+  -p MQTT_PORT, --mqtt_port MQTT_PORT
+                        MQTT Port (default: 1883)
+  -D MQTT_DISCOVERY_PREFIX, --mqtt_discovery_prefix MQTT_DISCOVERY_PREFIX
+                        Home Assistant MQTT topic prefix (default:
+                        homeassistant)
+  --name DEVICE_NAME    Home Assistant Device Name (default: JuiceBox)
   --juicebox_id JUICEBOX_ID
-                        JuiceBox ID
+                        JuiceBox ID. If not defined, will obtain it
+                        automatically.
   --update_udpc         Update UDPC on the JuiceBox. Requires --juicebox_host
   --juicebox_host JUICEBOX_HOST
-                        host or IP address of the Juicebox. required for --update_udpc
+                        Host or IP address of the JuiceBox. Required for
+                        --update_udpc or if --dst not defined.
   --juicepass_proxy_host JUICEPASS_PROXY_HOST
-                        EXTERNAL host or IP address of the machine running Juicepass Proxy. Optional: only necessary when using --update_udpc and it will be inferred from the address in --src if
-                        omitted.
+                        EXTERNAL host or IP address of the machine running
+                        JuicePass Proxy. Optional: only necessary when using
+                        --update_udpc and it will be inferred from the address
+                        in --src if omitted.
 ```
 
 _For **DST**, you should only use the IP address of the EnelX Server and **not** the fully qualified domain name (FQDN) to avoid DNS lookup loops._

--- a/README.MD
+++ b/README.MD
@@ -143,6 +143,9 @@ options:
                         JuicePass Proxy. Optional: only necessary when using
                         --update_udpc and it will be inferred from the address
                         in --src if omitted.
+  --config_loc CONFIG_LOC
+                        The location to store the config file (default:
+                        /~/.juicepassproxy)
 ```
 
 _For **DST**, you should only use the IP address of the EnelX Server and **not** the fully qualified domain name (FQDN) to avoid DNS lookup loops._

--- a/const.py
+++ b/const.py
@@ -1,4 +1,4 @@
-CONF_YAML = "/config/juicepassproxy.yaml"
+CONF_YAML = "juicepassproxy.yaml"
 
 # Defaults
 DEFAULT_ENELX_SERVER = "juicenet-udp-prod3-usa.enelx.com"

--- a/const.py
+++ b/const.py
@@ -1,0 +1,11 @@
+CONF_YAML = "/config/juicepassproxy.yaml"
+
+# Defaults
+DEFAULT_ENELX_SERVER = "juicenet-udp-prod3-usa.enelx.com"
+DEFAULT_ENELX_PORT = "8047"
+DEFAULT_SRC = "127.0.0.1"
+DEFAULT_DST = "54.161.147.91"
+DEFAULT_MQTT_HOST = "127.0.0.1"
+DEFAULT_MQTT_PORT = "1883"
+DEFAULT_MQTT_DISCOVERY_PREFIX = "homeassistant"
+DEFAULT_DEVICE_NAME = "JuiceBox"

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,215 +1,71 @@
 #!/bin/bash
 
-CONFIG_FILE="/config/juicepassproxy.yaml"
 JUICEPASSPROXY="/juicepassproxy/juicepassproxy.py"
-TELNET_GET_SERVER="/juicepassproxy/telnet_get_server.expect"
-TELNET_GET_JUICEBOX_ID="/juicepassproxy/telnet_get_juicebox_id.expect"
-
-ENELX_PORT_DEFAULT="8047"
-ENELX_SERVER_DEFAULT="juicenet-udp-prod3-usa.enelx.com"
-SRC_DEFAULT="127.0.0.1"
-DST_DEFAULT="54.161.147.91"
-
-RED='\033[1;31m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m' # No Color
 
 function logger() {
   if [ "${1^^}" != "DEBUG" ] || ($DEBUG && [ "${1^^}" = "DEBUG" ]); then
-    if [ "${1^^}" = "ERROR" ]; then
-      printf "%-15s ${RED}%-10s %s${NC}\n" "$(date +'%Y-%m-%d %H:%M:%S')" "${1^^}" "${2}"
-    elif [ "${1^^}" = "WARNING" ]; then
-      printf "%-15s ${YELLOW}%-10s %s${NC}\n" "$(date +'%Y-%m-%d %H:%M:%S')" "${1^^}" "${2}"
-    else
-      printf "%-15s %-10s %s\n" "$(date +'%Y-%m-%d %H:%M:%S')" "${1^^}" "${2}"
-    fi
+    printf "%-15s %-10s %s\n" "$(date +'%Y-%m-%d %H:%M:%S,%3N')" "${1^^}" "${2}"
   fi
-}
-
-function valid_ip() {
-    local  ip=$1
-    local  stat=1
-
-    if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-        OIFS=$IFS
-        IFS='.'
-        ip=($ip)
-        IFS=$OIFS
-        [[ ${ip[0]} -le 255 && ${ip[1]} -le 255 \
-            && ${ip[2]} -le 255 && ${ip[3]} -le 255 ]]
-        stat=$?
-    fi
-    return $stat
 }
 
 echo "--------------------------------"
-logger info "Starting JuicePass Proxy"
+logger INFO "Starting JuicePass Proxy"
 echo ""
-logger INFO "DEBUG: ${DEBUG}"
 
-if test -f ${CONFIG_FILE}; then
-  logger DEBUG  "Importing Config File"
-  JUICEBOX_ID_CONFIG="$(yq e '.JUICEBOX_ID' ${CONFIG_FILE})"
-  if [[ "${JUICEBOX_ID_CONFIG}" = "null" ]]; then
-    unset JUICEBOX_ID_CONFIG
-  fi
-  ENELX_SERVER_CONFIG="$(yq e '.ENELX_SERVER' ${CONFIG_FILE})"
-  if [[ "${ENELX_SERVER_CONFIG}" = "null" ]]; then
-    unset ENELX_SERVER_CONFIG
-  fi
-  ENELX_PORT_CONFIG="$(yq e '.ENELX_PORT' ${CONFIG_FILE})"
-  if [[ "${ENELX_PORT_CONFIG}" = "null" ]]; then
-    unset ENELX_PORT_CONFIG
-  fi
-  SRC_CONFIG="$(yq e '.SRC' ${CONFIG_FILE})"
-  if [[ "${SRC_CONFIG}" = "null" ]]; then
-    unset SRC_CONFIG
-  fi
-  DST_CONFIG="$(yq e '.DST' ${CONFIG_FILE})"
-  if [[ "${DST_CONFIG}" = "null" ]]; then
-    unset DST_CONFIG
-  fi
-else
-  logger DEBUG "No Config File Found."
+JPP_STRING="python3 ${JUICEPASSPROXY}"
+logger INFO "Docker Environment Variables:"
+if [[ ! -z "${DEVICE_NAME}" ]]; then
+  logger INFO "DEVICE_NAME: ${DEVICE_NAME}"
+  JPP_STRING+=" --name ${DEVICE_NAME}"
 fi
-
 if [[ ! -z "${JUICEBOX_HOST}" ]]; then
-  if [[ -z "${JUICEBOX_ID}" ]]; then
-    JUICEBOX_ID=$(${TELNET_GET_JUICEBOX_ID} ${JUICEBOX_HOST} | sed -n 8p)
-    if [[ ! -z "${JUICEBOX_ID}" ]]; then
-      logger DEBUG "Sucessfully obtained JuiceBox ID."
-      JUICEBOX_ID=${JUICEBOX_ID%?}
-    elif [[ ! -z "${JUICEBOX_ID_CONFIG}" ]]; then
-      logger WARNING "Cannot get JuiceBox ID. Using config."
-      JUICEBOX_ID=${JUICEBOX_ID_CONFIG}
-    else
-      echo -e "\n${RED}******************************************************************************${NC}"
-      logger ERROR "Cannot get JuiceBox ID from Telnet. If a JuiceBox ID is later set or is obtained via Telnet, it will likely create a new JuiceBox Device with new Entities in Home Assistant."
-      echo -e "${RED}******************************************************************************${NC}\n"
-      unset JUICEBOX_ID
-    fi
-  fi
-
-  TELNET_SERVER_STRING=$(${TELNET_GET_SERVER} ${JUICEBOX_HOST} | grep "UDPC" | head -1)
-  if [[ ! -z "${TELNET_SERVER_STRING}" ]]; then
-    logger DEBUG "Sucessfully obtained EnelX Server and Port."
-    #logger debug "TELNET_SERVER_STRING: ${TELNET_SERVER_STRING}"
-    ENELX_SERVER=$(echo ${TELNET_SERVER_STRING} | sed -E 's/(# 2 UDPC[ ]+)(.*)(:.*)/\2/g')
-    ENELX_PORT=$(echo ${TELNET_SERVER_STRING} | sed -E 's/(.*:)(.*)([ ]+.*)/\2/g')
-    if valid_ip ${ENELX_SERVER}; then
-      if [[ ! -z "${ENELX_SERVER_CONFIG}" ]] && ! valid_ip ${ENELX_SERVER_CONFIG}; then
-        logger WARNING "EnelX Server is already an IP. Using config."
-        ENELX_SERVER=${ENELX_SERVER_CONFIG}
-      else
-        logger ERROR "EnelX Server is already an IP. Not set in config. Using default."
-        ENELX_SERVER=${ENELX_SERVER_DEFAULT}
-      fi
-    fi
-  else
-    if [[ ! -z "${ENELX_SERVER_CONFIG}" ]]; then
-      logger WARNING "Cannot get EnelX Server from Telnet. Using config."
-      ENELX_SERVER=${ENELX_SERVER_CONFIG}
-    else
-      logger ERROR "Cannot get EnelX Server from Telnet. Not set in config. Using default."
-      ENELX_SERVER=${ENELX_SERVER_DEFAULT}
-    fi
-    if [[ ! -z "${ENELX_PORT_CONFIG}" ]]; then
-      logger WARNING "Cannot get EnelX Port from Telnet. Using config."
-      ENELX_PORT=${ENELX_PORT_CONFIG}
-    else
-      logger ERROR "Cannot get EnelX Port from Telnet. Not set in config. Using default."
-      ENELX_PORT=${ENELX_PORT_DEFAULT}
-    fi
-  fi
-else
-  logger DEBUG "JuiceBox Local IP not defined."
+  logger INFO "JUICEBOX_HOST: ${JUICEBOX_HOST}"
+  JPP_STRING+=" --juicebox_host ${JUICEBOX_HOST}"
 fi
-
-if [[ -z "${SRC}" ]]; then
-  SRC=$(ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p')
-  if valid_ip ${SRC}; then
-    logger DEBUG "Sucessfully obtained Docker Local IP."
-  elif [[ ! -z "${SRC_CONFIG}" ]]; then
-    logger WARNING "Cannot get Docker Local IP. Using config."
-    SRC=${SRC_CONFIG}
-  else
-    logger ERROR "Cannot get Docker Local IP. Not set in config. Using default."
-    SRC=${SRC_DEFAULT}
-  fi
-fi
-
-if [[ -z "${DST}" ]]; then
-  DST=$(dig +short @1.1.1.1 ${ENELX_SERVER} | awk '{ getline ; print $1 ; exit }')
-  if valid_ip ${DST}; then
-    logger DEBUG "Sucessfully obtained EnelX Server IP."
-  elif [[ ! -z "${DST_CONFIG}" ]]; then
-    logger WARNING "Cannot get EnelX Server IP. Using config."
-    DST=${DST_CONFIG}
-  else
-    logger ERROR "Cannot get EnelX Server IP. Not set in config. Using default."
-    DST=${DST_DEFAULT}
-  fi
-fi
-
-JPP_STRING="python3 ${JUICEPASSPROXY} --src ${SRC}:${ENELX_PORT} --dst ${DST}:${ENELX_PORT} --host ${MQTT_HOST} --port ${MQTT_PORT} --discovery-prefix ${MQTT_DISCOVERY_PREFIX} --name ${DEVICE_NAME}"
-echo ""
-logger INFO "DEVICE_NAME: ${DEVICE_NAME}"
-logger INFO "JUICEBOX_HOST: ${JUICEBOX_HOST}"
 if [[ ! -z "${JUICEBOX_ID}" ]]; then
   logger INFO "JUICEBOX_ID: ${JUICEBOX_ID}"
   JPP_STRING+=" --juicebox_id ${JUICEBOX_ID}"
 fi
-
-logger INFO "SRC: ${SRC}"
-logger INFO "DST: ${DST}"
-logger INFO "ENELX_SERVER: ${ENELX_SERVER}"
-logger INFO "ENELX_PORT: ${ENELX_PORT}"
-logger INFO "MQTT_HOST: ${MQTT_HOST}"
-logger INFO "MQTT_PORT: ${MQTT_PORT}"
+if [[ ! -z "${SRC}" ]]; then
+  logger INFO "SRC: ${SRC}"
+  JPP_STRING+=" --src ${SRC}"
+fi
+if [[ ! -z "${DST}" ]]; then
+  logger INFO "DST: ${DST}"
+  JPP_STRING+=" --dst ${DST}"
+fi
+if [[ ! -z "${MQTT_HOST}" ]]; then
+  logger INFO "MQTT_HOST: ${MQTT_HOST}"
+  JPP_STRING+=" --mqtt_host ${MQTT_HOST}"
+fi
+if [[ ! -z "${MQTT_PORT}" ]]; then
+  logger INFO "MQTT_PORT: ${MQTT_PORT}"
+  JPP_STRING+=" --mqtt_port ${MQTT_PORT}"
+fi
 if [[ ! -z "${MQTT_USER}" ]]; then
   logger INFO "MQTT_USER: ${MQTT_USER}"
-  JPP_STRING+=" --user ${MQTT_USER}"
+  JPP_STRING+=" --mqtt_user ${MQTT_USER}"
 fi
 if [[ ! -z "${MQTT_PASS}" ]]; then
   logger INFO "MQTT_PASS: $(echo ${MQTT_PASS} | sed -E 's/./*/g')"
-  JPP_STRING+=" --password ${MQTT_PASS}"
+  JPP_STRING+=" --mqtt_password ${MQTT_PASS}"
 fi
-
-logger INFO "MQTT_DISCOVERY_PREFIX: ${MQTT_DISCOVERY_PREFIX}"
-
+if [[ ! -z "${MQTT_DISCOVERY_PREFIX}" ]]; then
+  logger INFO "MQTT_DISCOVERY_PREFIX: ${MQTT_DISCOVERY_PREFIX}"
+  JPP_STRING+=" --mqtt_discovery_prefix ${MQTT_DISCOVERY_PREFIX}"
+fi
+if [[ ! -z "${JPP_HOST}" ]]; then
+  logger INFO "JPP_HOST: ${JPP_HOST}"
+  JPP_STRING+=" --juicepass_proxy_host ${JPP_HOST}"
+fi
 logger INFO "UPDATE_UDPC: ${UPDATE_UDPC}"
 if $UPDATE_UDPC; then
-  logger INFO "JPP_HOST: ${JPP_HOST}"
-  JPP_STRING+=" --juicebox_host ${JUICEBOX_HOST}"
-  JPP_STRING+=" --juicepass_proxy_host ${JPP_HOST}"
   JPP_STRING+=" --update_udpc"
 fi
-
+logger INFO "DEBUG: ${DEBUG}"
 if $DEBUG; then
   JPP_STRING+=" --debug"
 fi
 
-touch ${CONFIG_FILE}
-if [[ ! -z "${JUICEBOX_ID}" ]]; then
-  eval "yq e -i '.JUICEBOX_ID = \"${JUICEBOX_ID}\"' ${CONFIG_FILE}"
-fi
-if [[ ! -z "${ENELX_SERVER}" ]]; then
-  eval "yq e -i '.ENELX_SERVER = \"${ENELX_SERVER}\"' ${CONFIG_FILE}"
-fi
-if [[ ! -z "${ENELX_PORT}" ]]; then
-  eval "yq e -i '.ENELX_PORT = \"${ENELX_PORT}\"' ${CONFIG_FILE}"
-fi
-if [[ ! -z "${SRC}" ]]; then
-  eval "yq e -i '.SRC = \"${SRC}\"' ${CONFIG_FILE}"
-fi
-if [[ ! -z "${DST}" ]]; then
-  eval "yq e -i '.DST = \"${DST}\"' ${CONFIG_FILE}"
-fi
-if $DEBUG; then
-  echo -e "\n${CYAN}${CONFIG_FILE}:${NC}"
-  yq e /config/juicepassproxy.yaml
-  echo ""
-fi
-logger INFO "COMMAND: $(echo ${JPP_STRING} | sed -E 's/(.* --password )([\"]?[a-zA-Z0-9_\?\*\^\&\#\@\!]+[\"]?)/\1*****/g')"
+logger DEBUG "COMMAND: $(echo ${JPP_STRING} | sed -E 's/(.* --mqtt_password )([\"]?[a-zA-Z0-9_\?\*\^\&\#\@\!]+[\"]?)/\1*****/g')"
 eval ${JPP_STRING}

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -62,6 +62,7 @@ logger INFO "UPDATE_UDPC: ${UPDATE_UDPC}"
 if $UPDATE_UDPC; then
   JPP_STRING+=" --update_udpc"
 fi
+JPP_STRING+=" --config_loc /config"
 logger INFO "DEBUG: ${DEBUG}"
 if $DEBUG; then
   JPP_STRING+=" --debug"

--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -1,8 +1,25 @@
+#!/usr/bin/env python3
+
 import argparse
+import ipaddress
 import logging
+import socket
 import time
 from threading import Thread
 
+import yaml
+from const import (
+    CONF_YAML,
+    DEFAULT_DEVICE_NAME,
+    DEFAULT_DST,
+    DEFAULT_ENELX_PORT,
+    DEFAULT_ENELX_SERVER,
+    DEFAULT_MQTT_DISCOVERY_PREFIX,
+    DEFAULT_MQTT_HOST,
+    DEFAULT_MQTT_PORT,
+    DEFAULT_SRC,
+)
+from dns import resolver
 from ha_mqtt_discoverable import DeviceInfo, Settings
 from ha_mqtt_discoverable.sensors import Sensor, SensorInfo
 from juicebox_telnet import JuiceboxTelnet
@@ -224,7 +241,7 @@ class JuiceboxMessageHandler(object):
                 if entity:
                     entity.set_state(message.get(k))
         except Exception as e:
-            logging.exception(f"failed to publish sensor data: {e}")
+            logging.exception(f"Failed to publish sensor data to MQTT: {e}")
 
     def remote_data_handler(self, data):
         logging.debug("remote: {}".format(data))
@@ -304,6 +321,93 @@ class JuiceboxUDPCUpdater(object):
             time.sleep(interval)
 
 
+def get_local_ip():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(0)
+    try:
+        s.connect(("10.254.254.254", 1))
+        local_ip = s.getsockname()[0]
+    except Exception:
+        local_ip = None
+    s.close()
+    return local_ip
+
+
+def resolve_ip_external_dns(address, dns="1.1.1.1"):
+    res = resolver.Resolver()
+    res.nameservers = [dns]
+
+    answers = res.resolve(address)
+
+    if len(answers) > 0:
+        return answers[0].address
+    return None
+
+
+def is_valid_ip(test_ip):
+    try:
+        ipaddress.ip_address(test_ip)
+    except Exception:
+        return False
+    return True
+
+
+def get_enelx_server_port(juicebox_host):
+    try:
+        with JuiceboxTelnet(juicebox_host) as tn:
+            connections = tn.list()
+            # logging.debug(f"connections: {connections}")
+            for connection in connections:
+                if connection["type"] == "UDPC" and not is_valid_ip(
+                    connection["dest"].split(":")[0]
+                ):
+                    return connection["dest"]
+        return None
+
+    except Exception as e:
+        logging.warning(f"Error in getting EnelX Server and Port via Telnet: {e}")
+        return None
+
+
+def get_juicebox_id(juicebox_host):
+    try:
+        with JuiceboxTelnet(juicebox_host) as tn:
+            return (
+                tn.get("email.name_address")
+                .get("email.name_address")
+                .replace("b'", "")
+                .replace("'", "")
+            )
+
+        return None
+
+    except Exception as e:
+        logging.warning(f"Error in getting JuiceBox ID via Telnet: {e}")
+        return None
+
+
+def load_config():
+    config = {}
+    try:
+        with open(CONF_YAML, "r") as file:
+            config = yaml.safe_load(file)
+
+    except Exception as e:
+        logging.warning(f"Can't load {CONF_YAML}: {e}")
+    return config
+
+
+def write_config(config):
+    try:
+        with open(CONF_YAML, "w") as file:
+            yaml.dump(config, file)
+        return True
+    except Exception as e:
+        logging.warning(f"Can't write to {CONF_YAML}: {e}")
+
+    return False
+
+
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter, description=AP_DESCRIPTION
@@ -312,43 +416,54 @@ def main():
     arg_src = parser.add_argument(
         "-s",
         "--src",
-        required=True,
-        default="127.0.0.1:8047",
-        help="Source IP and port, (default: %(default)s)",
+        required=False,
+        type=str,
+        help="Source IP (and optional port). If not defined, will obtain it automatically. (Ex. 127.0.0.1:8047)",
     )
     parser.add_argument(
-        "-d", "--dst", required=True, help="Destination IP and port of EnelX Server."
+        "-d",
+        "--dst",
+        required=False,
+        type=str,
+        help="Destination IP (and optional port) of EnelX Server. If not defined, --juicebox_host required and then will obtain it automatically. (Ex. 127.0.0.1:8047)",
     )
     parser.add_argument("--debug", action="store_true")
-    parser.add_argument("-u", "--user", type=str, help="MQTT username")
-    parser.add_argument("-P", "--password", type=str, help="MQTT password")
+    parser.add_argument("-u", "--mqtt_user", type=str, help="MQTT Username")
+    parser.add_argument("-P", "--mqtt_password", type=str, help="MQTT Password")
     parser.add_argument(
         "-H",
-        "--host",
+        "--mqtt_host",
         type=str,
-        default="127.0.0.1",
-        help="MQTT hostname to connect to (default: %(default)s)",
+        default=DEFAULT_MQTT_HOST,
+        help="MQTT Hostname to connect to (default: %(default)s)",
     )
     parser.add_argument(
-        "-p", "--port", type=int, default=1883, help="MQTT port (default: %(default)s)"
+        "-p",
+        "--mqtt_port",
+        type=int,
+        default=DEFAULT_MQTT_PORT,
+        help="MQTT Port (default: %(default)s)",
     )
     parser.add_argument(
         "-D",
-        "--discovery-prefix",
+        "--mqtt_discovery_prefix",
         type=str,
-        dest="discovery_prefix",
-        default="homeassistant",
+        dest="mqtt_discovery_prefix",
+        default=DEFAULT_MQTT_DISCOVERY_PREFIX,
         help="Home Assistant MQTT topic prefix (default: %(default)s)",
     )
     parser.add_argument(
         "--name",
         type=str,
-        default="Juicebox",
+        default=DEFAULT_DEVICE_NAME,
         help="Home Assistant Device Name (default: %(default)s)",
         dest="device_name",
     )
     parser.add_argument(
-        "--juicebox_id", type=str, help="JuiceBox ID", dest="juicebox_id"
+        "--juicebox_id",
+        type=str,
+        help="JuiceBox ID. If not defined, will obtain it automatically.",
+        dest="juicebox_id",
     )
     parser.add_argument(
         "--update_udpc",
@@ -358,7 +473,7 @@ def main():
     arg_juicebox_host = parser.add_argument(
         "--juicebox_host",
         type=str,
-        help="Host or IP address of the JuiceBox. required for --update_udpc",
+        help="Host or IP address of the JuiceBox. Required for --update_udpc or if --dst not defined.",
     )
     parser.add_argument(
         "--juicepass_proxy_host",
@@ -371,11 +486,41 @@ def main():
 
     if args.debug:
         logging.getLogger().setLevel(logging.DEBUG)
+    else:
+        logging.getLogger().setLevel(logging.INFO)
 
     if args.update_udpc and not args.juicebox_host:
         raise argparse.ArgumentError(arg_juicebox_host, "juicebox_host is required")
 
-    localhost_src = args.src.startswith("0.") or args.src.startswith("127")
+    if not args.dst and not args.juicebox_host:
+        raise argparse.ArgumentError(arg_juicebox_host, "juicebox_host is required")
+
+    config = load_config()
+    if enelx_server_port := get_enelx_server_port(args.juicebox_host):
+        logging.debug(f"enelx_server_port: {enelx_server_port}")
+        enelx_server = enelx_server_port.split(":")[0]
+        enelx_port = enelx_server_port.split(":")[1]
+    else:
+        enelx_server = config.get("ENELX_SERVER", DEFAULT_ENELX_SERVER)
+        enelx_port = config.get("ENELX_PORT", DEFAULT_ENELX_PORT)
+    config.update({"ENELX_SERVER": enelx_server})
+    config.update({"ENELX_PORT": enelx_port})
+    logging.info(f"enelx_server: {enelx_server}")
+    logging.info(f"enelx_port: {enelx_port}")
+
+    if args.src:
+        if ":" in args.src:
+            src = args.src
+        else:
+            src = f"{args.src}:{enelx_port}"
+    elif local_ip := get_local_ip():
+        src = f"{local_ip}:{enelx_port}"
+    else:
+        src = f"{config.get('SRC',DEFAULT_SRC)}:{enelx_port}"
+    config.update({"SRC": src.split(":")[0]})
+    logging.info(f"src: {src}")
+
+    localhost_src = src.startswith("0.") or src.startswith("127")
     if args.update_udpc and localhost_src and not args.juicepass_proxy_host:
         raise argparse.ArgumentError(
             arg_src,
@@ -383,17 +528,44 @@ def main():
             " --juicepass_proxy_host must be used.",
         )
 
+    if args.dst:
+        if ":" in args.dst:
+            dst = args.dst
+        else:
+            dst = f"{args.dst}:{enelx_port}"
+    elif enelx_server_ip := resolve_ip_external_dns(enelx_server):
+        dst = f"{enelx_server_ip}:{enelx_port}"
+    else:
+        dst = f"{config.get('DST', DEFAULT_DST)}:{enelx_port}"
+    config.update({"DST": dst.split(":")[0]})
+    logging.info(f"dst: {dst}")
+
+    if juicebox_id := args.juicebox_id:
+        pass
+    elif juicebox_id := get_juicebox_id(args.juicebox_host):
+        pass
+    else:
+        juicebox_id = config.get("JUICEBOX_ID")
+    if juicebox_id:
+        config.update({"JUICEBOX_ID": juicebox_id})
+        logging.info(f"juicebox_id: {juicebox_id}")
+    else:
+        logging.error(
+            "Cannot get JuiceBox ID from Telnet and not in Config. If a JuiceBox ID is later set or is obtained via Telnet, it will likely create a new JuiceBox Device with new Entities in Home Assistant."
+        )
+    write_config(config)
+
     mqttsettings = Settings.MQTT(
-        host=args.host,
-        port=args.port,
-        username=args.user,
-        password=args.password,
-        discovery_prefix=args.discovery_prefix,
+        host=args.mqtt_host,
+        port=args.mqtt_port,
+        username=args.mqtt_user,
+        password=args.mqtt_password,
+        discovery_prefix=args.mqtt_discovery_prefix,
     )
     handler = JuiceboxMessageHandler(
         mqtt_settings=mqttsettings,
         device_name=args.device_name,
-        juicebox_id=args.juicebox_id,
+        juicebox_id=juicebox_id,
     )
 
     pyproxy.LOCAL_DATA_HANDLER = handler.local_data_handler
@@ -403,13 +575,13 @@ def main():
     udpc_updater = None
 
     if args.update_udpc:
-        address = args.src.split(":")
+        address = src.split(":")
         jpp_host = args.juicepass_proxy_host or address[0]
         udpc_updater = JuiceboxUDPCUpdater(args.juicebox_host, jpp_host, address[1])
         udpc_updater_thread = Thread(target=udpc_updater.start)
         udpc_updater_thread.start()
 
-    pyproxy.udp_proxy(args.src, args.dst)
+    pyproxy.udp_proxy(src, dst)
 
     if udpc_updater is not None and udpc_updater_thread is not None:
         udpc_updater.run_event = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-ha-mqtt-discoverable>=0.10.0
-paho-mqtt>=1.6.1
+ha-mqtt-discoverable >= 0.10.0
+paho-mqtt >= 1.6.1
+dnspython >= 2.0.0
+pyyaml

--- a/telnet_get_juicebox_id.expect
+++ b/telnet_get_juicebox_id.expect
@@ -1,9 +1,0 @@
-#!/usr/bin/expect
-
-set host [lindex $argv 0]
-
-set timeout 10
-spawn telnet $host 2000
-expect ">"
-send "get email.name_address\r"
-expect ">"

--- a/telnet_get_server.expect
+++ b/telnet_get_server.expect
@@ -1,9 +1,0 @@
-#!/usr/bin/expect
-
-set host [lindex $argv 0]
-
-set timeout 10
-spawn telnet $host 2000
-expect ">"
-send "list\r"
-expect ">"


### PR DESCRIPTION
# Breaking Changes

* Renamed juicepassproxy.py MQTT options for clarity:

Old | New | 
-- | -- 
--user | `--mqtt_user`
--password | `--mqtt_password`
--host | `--mqtt_host`
--port | `--mqtt_port`

* Not exactly breaking, but removed the following Docker Environment Variables as they are no longer necessary:
    * ENELX_SERVER
    * ENELX_PORT

# Fixes/Enhancements

* Moved all config manipulation, telnet, and IP lookups into Python
* Changed default log level to INFO
* Made `src` optional. Will get local IP automatically (but not 127.0.0.1).
* Made `dst` optional if `juicebox_host` is defined. Will get the EnelX Server via telnet and then find its IP using an external DNS.
* Made port optional in `src` and `dst`. Will get it by telnet if `juicebox_host` is defined.
* Added `config_loc` for the location of the config file. Default is ~/.juicepassproxy

Fixes #24 