### PR TITLE
Prevent UnboundLocalError in basic_message_try_parse

### DIFF
--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -183,6 +183,7 @@ class JuiceboxMessageHandler(object):
         message = {"type": "basic"}
         message["current"] = 0
         message["energy_session"] = 0
+        active = True
         for part in str(data).split(","):
             if part[0] == "S":
                 message["status"] = {


### PR DESCRIPTION
Should keep #37 from crashing JPP but is not a fix for detecting errors in the stream.