### PR TITLE
Send Debug Messages to MQTT

### DIFF
--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -45,6 +45,7 @@ class JuiceboxMessageHandler(object):
             "temperature": None,
             "voltage": None,
             "power": None,
+            "debug_message": None,
         }
         self._init_devices()
 
@@ -71,15 +72,34 @@ class JuiceboxMessageHandler(object):
         self._init_device_temperature(device_info)
         self._init_device_voltage(device_info)
         self._init_device_power(device_info)
+        self._init_debug_message(device_info)
 
     def _init_device_status(self, device_info):
         name = "Status"
         sensor_info = SensorInfo(
-            name=name, unique_id=f"{self.juicebox_id} {name}", device=device_info
+            name=name,
+            unique_id=f"{self.juicebox_id} {name}",
+            icon="mdi:ev-station",
+            device=device_info,
         )
         settings = Settings(mqtt=self.mqtt_settings, entity=sensor_info)
         sensor = Sensor(settings)
         self.entities["status"] = sensor
+
+    def _init_debug_message(self, device_info):
+        name = "Last Debug Message"
+        sensor_info = SensorInfo(
+            name=name,
+            unique_id=f"{self.juicebox_id} {name}",
+            expire_after=60,
+            enabled_by_default=False,
+            icon="mdi:bug",
+            entity_category="diagnostic",
+            device=device_info,
+        )
+        settings = Settings(mqtt=self.mqtt_settings, entity=sensor_info)
+        sensor = Sensor(settings)
+        self.entities["debug_message"] = sensor
 
     def _init_device_current(self, device_info):
         name = "Current"
@@ -214,11 +234,33 @@ class JuiceboxMessageHandler(object):
         message["power"] = round(
             message.get("voltage", 0) * message.get("current", 0), 2
         )
-        logging.debug(f"message: {message}")
+        return message
+
+    def debug_message_try_parse(self, data):
+        message = {"type": "debug"}
+        dbg_data = (
+            str(data)
+            .replace("https://", "https//")
+            .replace("http://", "http//")
+            .split(":")
+        )
+        dbg_level_abbr = dbg_data[1].split(",")[1]
+        if dbg_level_abbr == "NFO":
+            dbg_level = "INFO"
+        elif dbg_level_abbr == "WRN":
+            dbg_level = "WARNING"
+        elif dbg_level_abbr == "ERR":
+            dbg_level = "ERROR"
+        else:
+            dbg_level = dbg_level_abbr
+        dbg_msg = (
+            dbg_data[2].replace("https//", "https://").replace("http//", "http://")
+        )
+        message["debug_message"] = f"{dbg_level}: {dbg_msg}"
         return message
 
     def basic_message_publish(self, message):
-        logging.debug("basic message {}".format(message))
+        logging.debug(f"{message.get('type')} message: {message}")
         try:
             for k in message:
                 entity = self.entities.get(k)
@@ -232,8 +274,11 @@ class JuiceboxMessageHandler(object):
         return data
 
     def local_data_handler(self, data):
-        logging.debug("local : {}".format(data))
-        message = self.basic_message_try_parse(data)
+        logging.debug("local: {}".format(data))
+        if ":DBG," in str(data):
+            message = self.debug_message_try_parse(data)
+        else:
+            message = self.basic_message_try_parse(data)
         if message:
             self.basic_message_publish(message)
         return data
@@ -396,7 +441,9 @@ def main():
         device_name=args.device_name,
         juicebox_id=args.juicebox_id,
     )
-
+    handler.basic_message_publish(
+        {"type": "debug", "debug_message": "INFO: Starting JuicePass Proxy"}
+    )
     pyproxy.LOCAL_DATA_HANDLER = handler.local_data_handler
     pyproxy.REMOTE_DATA_HANDLER = handler.remote_data_handler
 


### PR DESCRIPTION
Fixes #37 

Creates a Last Debug Message sensor:
* Goes to the Diagnostics section for the JuiceBox device in HA
* Is disabled by default
* Message is active for 60 seconds before sensor resets to Unavailable
* Sends a Startup message when JPP Starts

<img width="1084" alt="2023-11-23_22-05-10 957" src="https://github.com/snicker/juicepassproxy/assets/6526076/f961bb29-7069-4cd2-b440-24f6816b9553">
<img width="333" alt="2023-11-23_22-29-27 148" src="https://github.com/snicker/juicepassproxy/assets/6526076/44bc519d-a435-4883-8154-841fe41371b5">
<img width="332" alt="2023-11-23_22-24-06 995" src="https://github.com/snicker/juicepassproxy/assets/6526076/204ea135-a386-442c-a1ae-cf9872e13521">
