### PR TITLE
Improve parsing of basic messages

### DIFF
--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import re
 import time
 from threading import Thread
 
@@ -184,7 +185,14 @@ class JuiceboxMessageHandler(object):
         message["current"] = 0
         message["energy_session"] = 0
         active = True
-        for part in str(data).split(","):
+        parts = re.split(r",|!|:", str(data).replace("b'", "").replace("'", ""))
+        parts.pop(0)  # JuiceBox ID
+        parts.pop(-1)  # Ending blank
+        parts.pop(-1)  # Checksum
+
+        # Undefined parts: v, F, u, M, C, m, t, i, e, r, b, B, P, p
+        # s = Counter
+        for part in parts:
             if part[0] == "S":
                 message["status"] = {
                     "S0": "Unplugged",


### PR DESCRIPTION
Right now this doesn't really change anything but it will help if we need to parse additional fields in the data stream. Ensures that all components are separated out. Prior logic had the JuiceBox ID and the first section of the stream combined and the last section and the checksum combined together.