### PR TITLE
Catch errors on IP resolve

### DIFF
--- a/juicepassproxy.py
+++ b/juicepassproxy.py
@@ -382,7 +382,8 @@ def get_local_ip():
     try:
         s.connect(("10.254.254.254", 1))
         local_ip = s.getsockname()[0]
-    except Exception:
+    except Exception as e:
+        logging.warning(f"Unable to get local IP: {e}")
         local_ip = None
     s.close()
     return local_ip
@@ -391,8 +392,15 @@ def get_local_ip():
 def resolve_ip_external_dns(address, dns="1.1.1.1"):
     res = resolver.Resolver()
     res.nameservers = [dns]
-
-    answers = res.resolve(address)
+    try:
+        answers = res.resolve(address)
+    except (
+        resolver.LifetimeTimeout,
+        resolver.NoNameservers,
+        resolver.NoAnswer,
+    ) as e:
+        logging.warning(f"Unable to resolve {address}: {e}")
+        return None
 
     if len(answers) > 0:
         return answers[0].address


### PR DESCRIPTION
Wanted to catch DNS resolve errors. I caused it due to my router settings, but JPP will crash if it can't resolve the EnelX server IP with the external 1.1.1.1 IP.

```
juicepassproxy  | Traceback (most recent call last):
juicepassproxy  |   File "/juicepassproxy/juicepassproxy.py", line 661, in <module>
juicepassproxy  |     main()
juicepassproxy  |   File "/juicepassproxy/juicepassproxy.py", line 603, in main
juicepassproxy  |     elif enelx_server_ip := resolve_ip_external_dns(enelx_server):
juicepassproxy  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
juicepassproxy  |   File "/juicepassproxy/juicepassproxy.py", line 395, in resolve_ip_external_dns
juicepassproxy  |     answers = res.resolve(address)
juicepassproxy  |               ^^^^^^^^^^^^^^^^^^^^
juicepassproxy  |   File "/usr/local/lib/python3.12/site-packages/dns/resolver.py", line 1321, in resolve
juicepassproxy  |     timeout = self._compute_timeout(start, lifetime, resolution.errors)
juicepassproxy  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
juicepassproxy  |   File "/usr/local/lib/python3.12/site-packages/dns/resolver.py", line 1075, in _compute_timeout
juicepassproxy  |     raise LifetimeTimeout(timeout=duration, errors=errors)
juicepassproxy  | dns.resolver.LifetimeTimeout: The resolution lifetime expired after 5.401 seconds: Server Do53:1.1.1.1@53 answered The DNS operation timed out.; Server Do53:1.1.1.1@53 answered The DNS operation timed out.; Server Do53:1.1.1.1@53 answered The DNS operation timed out.
```

Now it handles it as just a Warning and JPP will fallback to the Enel X IP in the Config or the Default one:
```
juicepassproxy  | 2023-12-11 07:57:14,477 WARNING    Unable to resolve juicenet-udp-prod3-usa.enelx.com: The resolution lifetime expired after 5.402 seconds: Server Do53:1.1.1.1@53 answered The DNS operation timed out.; Server Do53:1.1.1.1@53 answered The DNS operation timed out.; Server Do53:1.1.1.1@53 answered The DNS operation timed out.
```