### PR TITLE
pin ha-mqtt-discoverable to 0.13.1 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ha-mqtt-discoverable >= 0.10.0
+ha-mqtt-discoverable == 0.13.1
 paho-mqtt >= 1.6.1
 dnspython >= 2.0.0
 pyyaml


### PR DESCRIPTION
fixes #74 